### PR TITLE
Add visibility to deprecation warning at the command line

### DIFF
--- a/src/Packagist/WebBundle/Package/SymlinkDumper.php
+++ b/src/Packagist/WebBundle/Package/SymlinkDumper.php
@@ -292,6 +292,7 @@ class SymlinkDumper
             $this->rootFile['notify-batch'] = $this->router->generate('track_download_batch');
             $this->rootFile['providers-url'] = $this->router->generate('home') . 'p/%package%$%hash%.json';
             $this->rootFile['search'] = $this->router->generate('search', array('_format' => 'json')) . '?q=%query%';
+            $this->rootFile['warning'] = 'Drupal Packagist is deprecated, you should use the official Package Repository from Drupal.org instead: (https://www.drupal.org/node/2718229). This site will be available until January 2017';
 
             if ($verbose) {
                 echo 'Dumping individual listings'.PHP_EOL;


### PR DESCRIPTION
Composer has the ability to display warning messages from repositories to end users: (https://github.com/composer/composer/blob/ff4e2ec2191e93e90fb954b699135c561bd2ee42/src/Composer/Repository/ComposerRepository.php#L488-L488)

We should use that to notify people of the deprecation.  I havent tested this but I believe it should be straightforward.
